### PR TITLE
Fix typo in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ all: $(MBR)
 test: $(MBR)
 	qemu-system-i386 -drive format=raw,file=$(MBR) -net none
 
-# Create bootable USP stick
+# Create bootable USB stick
 
 iso: $(ISO)
 


### PR DESCRIPTION
Fix typo in Makefile: 'USP' to 'USB'

Signed-off-by: Renê de Souza Pinto <rene@renesp.com.br>